### PR TITLE
Fixed the incorrect part in "Associativity"

### DIFF
--- a/op_exp.asciidoc
+++ b/op_exp.asciidoc
@@ -227,9 +227,18 @@ expression, then you can write something like `(2 + 3) * 4`.
 === Associativity
 
 Operators are usually associated from left to right. This means that operators with the same
-precedence are evaluated in a left to right manner. For example, `2 + 3 + 4` is evaluated as `(2 +
-3) + 4`. Some operators like assignment operators have right to left associativity i.e. `a = b = c`
-is treated as `a = (b = c)`.
+precedence are evaluated in a left to right manner. For example, `2 + 3 + 4` is evaluated as `(2 + 3) + 4`. 
+
+Assignment operators are the same. For example, `a = b = c` is treated as: 
+
+[source,python]
+--------------------------------------------------
+temp = c
+a = temp
+b = temp
+--------------------------------------------------
+
+In this case `temp` is a temporary variable, actually it does not exist, or we can say it will be deleted then.
 
 === Expressions
 


### PR DESCRIPTION
Python doesn't treat `a = b = c` as `a = (b = c)`. It's more like  `temp = c`, then `a = temp`,  followed by `b = temp`.